### PR TITLE
Add model comparison tool link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains the source code for Le Lu’s professional website. It 
 - **index.html**: Main HTML structure.
 - **style.css**: Modern CSS styling for layout and design.
 - **script.js**: JavaScript for smooth scrolling.
+- **ModelsComparison_v1.02.html**: Interactive curve fitting model comparison tool.
 - **images/profile.jpg**: Your profile photo (rename your actual image to `profile.jpg` and place it in the images folder).
 - **README.md**: This documentation.
 - **LICENSE**: License for this project.

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
           <li><a href="#experience">Experience</a></li>
           <li><a href="#education">Education</a></li>
           <li><a href="#skills">Skills</a></li>
+          <li><a href="#tools">Tools</a></li>
           <li><a href="#contact">Contact</a></li>
         </ul>
       </div>
@@ -172,6 +173,18 @@
           <li>Chinese (Native or Bilingual)</li>
         </ul>
       </div>
+  </div>
+  </section>
+
+  <!-- Tools Section -->
+  <section id="tools" class="section">
+    <div class="container">
+      <h2>Web Tools</h2>
+      <p>
+        Explore my interactive
+        <a href="ModelsComparison_v1.02.html" target="_blank">Curve Fitting Model Comparison Tool</a>
+        to compare machine learning models for curve fitting tasks.
+      </p>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- add navigation entry for Tools
- link to the curve fitting model comparison HTML
- document new tool in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687d1631e7808330bb6b36d1ca58b211