### PR TITLE
Add TSMC-era patents and polish CSS (cache-bust)

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css?v=20260418" />
 </head>
 <body>
   <div class="page">
@@ -269,6 +269,6 @@
     </main>
   </div>
 
-  <script src="script.js"></script>
+  <script src="script.js?v=20260418"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -206,6 +206,18 @@
         <h2>Patents</h2>
         <ul class="pub-list">
           <li>
+            <span class="pub-title">Method for Detecting Target Substance.</span>
+            <span class="pub-authors">Inventor: L. Lu.</span>
+            <span class="pub-venue">US Patent <strong>US20260023060A1</strong>, 2026.</span>
+            <a class="doi" href="https://patents.google.com/patent/US20260023060A1" target="_blank" rel="noopener">US20260023060A1</a>
+          </li>
+          <li>
+            <span class="pub-title">Brush for Cleaning Wafers After Chemical Mechanical Polishing (CMP) Process.</span>
+            <span class="pub-authors">Inventors: Jhih-Fong Lin, Liqing Wen, Le Lu (DGC).</span>
+            <span class="pub-venue">US Patent <strong>US20240180324A1</strong>, 2024.</span>
+            <a class="doi" href="https://patents.google.com/patent/US20240180324A1" target="_blank" rel="noopener">US20240180324A1</a>
+          </li>
+          <li>
             <span class="pub-title">Soluble polybenzofuran, preparation method thereof and application thereof in synthesizing 5-substituted benzofuran.</span>
             <span class="pub-authors">Inventor: Le Lu.</span>
           </li>

--- a/style.css
+++ b/style.css
@@ -1,32 +1,57 @@
+/* ================================================================
+   lulelaboratory.github.io — academic, research-clean
+   Palette: deep indigo accent (#1f3a5f) on near-white.
+   ================================================================ */
+
 :root {
-  --ink: #1a1a1a;
-  --ink-soft: #3b3b3b;
+  --ink: #111418;
+  --ink-soft: #3a3f47;
   --muted: #6b7280;
   --rule: #e5e7eb;
+  --rule-soft: #f0f2f5;
   --bg: #ffffff;
-  --bg-soft: #fafafa;
+  --bg-soft: #f7f8fa;
   --accent: #1f3a5f;
-  --accent-hover: #33567f;
+  --accent-2: #335c8a;
+  --accent-hover: #2c5284;
+  --accent-tint: #eaf0f8;
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+  --shadow-md: 0 10px 30px rgba(15, 23, 42, 0.08);
   --max-main: 820px;
-  --sidebar: 280px;
-  --gap: 56px;
-  --sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  --serif: 'Source Serif 4', Charter, 'Iowan Old Style', Georgia, serif;
+  --sidebar: 300px;
+  --gap: 64px;
+  --radius: 12px;
+  --sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --serif: 'Source Serif 4', 'Source Serif Pro', Charter, 'Iowan Old Style', Georgia, serif;
 }
 
-* { box-sizing: border-box; }
+/* Reset — defensive so cached older rules can't leak through */
+*, *::before, *::after { box-sizing: border-box; }
 
 html { scroll-behavior: smooth; }
 
 body {
   margin: 0;
+  padding: 0;
   background: var(--bg);
   color: var(--ink);
   font-family: var(--sans);
   font-size: 16px;
   line-height: 1.65;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: left;
 }
+
+h1, h2, h3, h4, h5, h6, p, ul, ol, figure, blockquote {
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+
+ul, ol { list-style: none; }
+
+img { max-width: 100%; display: block; }
 
 a {
   color: var(--accent);
@@ -40,78 +65,118 @@ a:hover {
   border-bottom-color: currentColor;
 }
 
+/* ================================================================
+   Top accent bar — thin gradient strip across the page.
+   ================================================================ */
+body::before {
+  content: "";
+  display: block;
+  height: 4px;
+  background: linear-gradient(90deg, #1f3a5f 0%, #335c8a 50%, #5e81ac 100%);
+}
+
+/* ================================================================
+   Page grid
+   ================================================================ */
 .page {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 64px 40px;
+  padding: 56px 40px 40px;
   display: grid;
   grid-template-columns: var(--sidebar) 1fr;
   gap: var(--gap);
   align-items: start;
 }
 
-/* ---------- Sidebar ---------- */
+/* ================================================================
+   Sidebar
+   ================================================================ */
 .sidebar {
   position: sticky;
-  top: 40px;
+  top: 32px;
   align-self: start;
 }
 
 .portrait {
-  width: 180px;
-  height: 180px;
+  width: 200px;
+  height: 200px;
   object-fit: cover;
   border-radius: 50%;
   display: block;
-  margin-bottom: 24px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, .08);
+  margin: 0 0 20px;
+  padding: 4px;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  box-shadow: var(--shadow-md);
 }
 
 .name {
   font-family: var(--serif);
   font-weight: 600;
-  font-size: 2rem;
-  line-height: 1.15;
-  margin: 0 0 6px;
-  letter-spacing: -0.01em;
+  font-size: 2.1rem;
+  line-height: 1.1;
+  letter-spacing: -0.015em;
+  color: var(--ink);
+  margin-bottom: 6px;
 }
 
 .role {
-  margin: 0 0 2px;
   font-weight: 600;
   color: var(--ink);
+  font-size: 0.98rem;
+  line-height: 1.4;
+  margin-bottom: 2px;
 }
 
 .tagline {
-  margin: 0 0 2px;
   color: var(--ink-soft);
-  font-size: .95rem;
+  font-size: 0.92rem;
+  line-height: 1.45;
+  margin-bottom: 4px;
 }
 
 .location {
-  margin: 0 0 20px;
   color: var(--muted);
-  font-size: .9rem;
+  font-size: 0.88rem;
+  margin-bottom: 18px;
 }
 
 .contact {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding-bottom: 20px;
+  gap: 8px;
+  padding: 16px 0 18px;
   margin-bottom: 20px;
+  border-top: 1px solid var(--rule);
   border-bottom: 1px solid var(--rule);
-  font-size: .92rem;
+  font-size: 0.92rem;
 }
 
 .contact a {
   color: var(--ink-soft);
   word-break: break-word;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  line-height: 1.35;
+  padding: 2px 0;
+}
+
+.contact a::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+  opacity: 0.55;
 }
 
 .contact a:hover {
   color: var(--accent);
+  border-bottom: 1px solid transparent;
 }
+
+.contact a:hover::before { opacity: 1; }
 
 .side-block {
   margin-bottom: 22px;
@@ -119,32 +184,34 @@ a:hover {
 
 .side-block h2 {
   font-family: var(--sans);
-  font-size: .78rem;
+  font-size: 0.75rem;
   font-weight: 700;
-  letter-spacing: .08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
-  margin: 0 0 8px;
+  margin-bottom: 10px;
 }
 
 .side-block ul {
   list-style: none;
   padding: 0;
-  margin: 0;
 }
 
 .side-block li {
-  font-size: .92rem;
+  font-size: 0.92rem;
   padding: 3px 0;
   color: var(--ink-soft);
+  line-height: 1.45;
 }
 
 .side-block .muted {
   color: var(--muted);
-  font-size: .82rem;
+  font-size: 0.82rem;
 }
 
-/* ---------- Main column ---------- */
+/* ================================================================
+   Main column
+   ================================================================ */
 .main {
   max-width: var(--max-main);
   min-width: 0;
@@ -153,33 +220,44 @@ a:hover {
 .section-nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 18px;
-  padding-bottom: 18px;
-  margin-bottom: 24px;
+  gap: 22px;
+  padding: 14px 0;
+  margin-bottom: 8px;
   border-bottom: 1px solid var(--rule);
-  font-size: .88rem;
+  font-size: 0.86rem;
   position: sticky;
   top: 0;
-  background: var(--bg);
-  z-index: 10;
-  padding-top: 18px;
-  margin-top: -18px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: saturate(180%) blur(8px);
+  -webkit-backdrop-filter: saturate(180%) blur(8px);
+  z-index: 20;
 }
 
 .section-nav a {
   color: var(--muted);
   border-bottom: none;
-  padding: 2px 0;
-  transition: color .15s ease;
+  padding: 4px 0;
+  font-weight: 500;
+  position: relative;
 }
 
-.section-nav a:hover,
+.section-nav a:hover { color: var(--accent); }
+
 .section-nav a.active {
   color: var(--accent);
 }
 
+.section-nav a.active::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: -15px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 1px;
+}
+
 .section {
-  padding: 24px 0 40px;
+  padding: 36px 0 28px;
   scroll-margin-top: 80px;
 }
 
@@ -190,20 +268,41 @@ a:hover {
 .section h2 {
   font-family: var(--serif);
   font-weight: 600;
-  font-size: 1.6rem;
-  margin: 0 0 20px;
+  font-size: 1.75rem;
   color: var(--ink);
-  letter-spacing: -0.01em;
+  letter-spacing: -0.015em;
+  margin-bottom: 20px;
+  position: relative;
+  padding-left: 16px;
+  text-align: left;
+}
+
+.section h2::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.3em;
+  bottom: 0.3em;
+  width: 4px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, var(--accent) 0%, var(--accent-2) 100%);
 }
 
 .section p {
-  margin: 0 0 14px;
+  margin-bottom: 14px;
   color: var(--ink-soft);
+  text-align: left;
 }
 
-/* ---------- Experience ---------- */
+.section p:last-child { margin-bottom: 0; }
+
+/* ================================================================
+   Experience
+   ================================================================ */
 .entry {
-  margin-bottom: 28px;
+  margin-bottom: 32px;
+  padding-left: 16px;
+  border-left: 2px solid var(--rule-soft);
 }
 
 .entry:last-child { margin-bottom: 0; }
@@ -218,9 +317,9 @@ a:hover {
 }
 
 .entry-head h3 {
-  font-size: 1.1rem;
+  font-size: 1.12rem;
   font-weight: 600;
-  margin: 0;
+  color: var(--ink);
 }
 
 .sub-entry {
@@ -233,33 +332,36 @@ a:hover {
 }
 
 .sub-entry h4 {
-  font-size: .98rem;
+  font-size: 0.98rem;
   font-weight: 500;
   color: var(--ink-soft);
-  margin: 0;
 }
 
 .meta {
-  font-size: .85rem;
+  font-size: 0.84rem;
   color: var(--muted);
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .entry ul {
-  margin: 10px 0 0;
-  padding-left: 20px;
+  margin-top: 10px;
+  padding-left: 18px;
+  list-style: disc;
   color: var(--ink-soft);
 }
 
 .entry li {
-  margin-bottom: 4px;
+  margin-bottom: 5px;
+  padding-left: 2px;
 }
 
-/* ---------- Education ---------- */
+/* ================================================================
+   Education
+   ================================================================ */
 .education {
   list-style: none;
   padding: 0;
-  margin: 0;
 }
 
 .education li {
@@ -267,7 +369,7 @@ a:hover {
   justify-content: space-between;
   align-items: baseline;
   gap: 16px;
-  padding: 8px 0;
+  padding: 10px 0;
   border-bottom: 1px dashed var(--rule);
   color: var(--ink-soft);
   flex-wrap: wrap;
@@ -275,45 +377,71 @@ a:hover {
 
 .education li:last-child { border-bottom: none; }
 
-/* ---------- Publications & Patents ---------- */
+.education strong { color: var(--ink); font-weight: 600; }
+
+/* ================================================================
+   Publications & Patents
+   ================================================================ */
 .pub-list {
-  margin: 0;
+  list-style: decimal;
   padding-left: 22px;
 }
 
 .pub-list li {
-  margin-bottom: 14px;
+  margin-bottom: 16px;
   color: var(--ink-soft);
+  padding-left: 4px;
+  line-height: 1.55;
 }
+
+.pub-list li::marker {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+#patents .pub-list { list-style: none; padding-left: 0; }
+#patents .pub-list li { padding-left: 0; }
 
 .pub-title {
   display: block;
   color: var(--ink);
   font-weight: 500;
+  margin-bottom: 2px;
 }
 
 .pub-authors,
 .pub-venue {
   display: block;
-  font-size: .92rem;
+  font-size: 0.92rem;
 }
 
-.pub-venue em {
-  color: var(--ink);
-}
+.pub-venue em { color: var(--ink); font-style: italic; }
 
 .doi {
-  font-size: .85rem;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  display: inline-block;
+  margin-top: 2px;
+  font-size: 0.82rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  padding: 2px 8px;
+  background: var(--accent-tint);
+  border-radius: 4px;
+  border: none !important;
+}
+
+.doi:hover {
+  background: #dce6f2;
+  border: none !important;
 }
 
 .note {
-  margin-top: 16px;
-  font-size: .9rem;
+  margin-top: 18px;
+  font-size: 0.9rem;
   color: var(--muted);
 }
 
-/* ---------- Projects ---------- */
+/* ================================================================
+   Projects
+   ================================================================ */
 .project-grid {
   display: grid;
   grid-template-columns: 1fr;
@@ -322,76 +450,108 @@ a:hover {
 
 .project {
   border: 1px solid var(--rule);
-  border-radius: 10px;
-  padding: 20px 22px;
-  background: var(--bg-soft);
-  transition: border-color .15s ease, box-shadow .15s ease;
+  border-radius: var(--radius);
+  padding: 22px 24px;
+  background: var(--bg);
+  transition: border-color .2s ease, box-shadow .2s ease, transform .2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.project::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 3px;
+  background: linear-gradient(180deg, var(--accent) 0%, var(--accent-2) 100%);
+  opacity: 0;
+  transition: opacity .2s ease;
 }
 
 .project:hover {
-  border-color: var(--accent);
-  box-shadow: 0 4px 16px rgba(31, 58, 95, .08);
+  border-color: var(--accent-2);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
 }
+
+.project:hover::before { opacity: 1; }
 
 .project h3 {
   font-family: var(--serif);
-  font-size: 1.15rem;
+  font-size: 1.2rem;
   font-weight: 600;
-  margin: 0 0 10px;
+  color: var(--ink);
+  margin-bottom: 10px;
 }
 
 .project p {
-  font-size: .95rem;
-  margin: 0 0 8px;
+  font-size: 0.94rem;
+  margin-bottom: 10px;
+  color: var(--ink-soft);
 }
 
 .project .stack {
-  font-size: .82rem;
+  font-size: 0.8rem;
   color: var(--muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  margin-bottom: 4px;
 }
 
 .project-links {
   margin-top: 4px;
-  font-size: .9rem;
+  font-size: 0.9rem;
 }
 
-/* ---------- Footer ---------- */
+.project-links a { font-weight: 500; }
+
+/* ================================================================
+   Footer
+   ================================================================ */
 .footer {
-  padding: 32px 0 0;
-  margin-top: 24px;
+  padding: 28px 0 0;
+  margin-top: 20px;
   border-top: 1px solid var(--rule);
   color: var(--muted);
-  font-size: .88rem;
+  font-size: 0.86rem;
+  text-align: left;
 }
 
 .footer p { margin: 0; }
 
-/* ---------- Responsive ---------- */
-@media (max-width: 860px) {
+/* ================================================================
+   Responsive
+   ================================================================ */
+@media (max-width: 900px) {
+  :root { --gap: 40px; }
   .page {
     grid-template-columns: 1fr;
-    gap: 40px;
     padding: 40px 24px;
   }
   .sidebar {
     position: static;
-    text-align: left;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--rule);
   }
   .portrait {
-    width: 140px;
-    height: 140px;
+    width: 160px;
+    height: 160px;
   }
   .section-nav {
     position: static;
-    padding-top: 0;
-    margin-top: 0;
+    background: transparent;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    margin-top: 8px;
   }
+  .section-nav a.active::after { bottom: -8px; }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 520px) {
   body { font-size: 15px; }
   .name { font-size: 1.7rem; }
-  .section h2 { font-size: 1.35rem; }
-  .page { padding: 32px 18px; }
+  .section h2 { font-size: 1.4rem; }
+  .page { padding: 28px 18px; }
+  .portrait { width: 140px; height: 140px; }
+  .entry { padding-left: 12px; }
+  .section { padding: 28px 0 22px; }
 }


### PR DESCRIPTION
## Summary

Follow-up to the initial rebuild (PR #3). Two commits that didn't make it into that merge:

- **`b00ed35` — Polish design and cache-bust CSS/JS.** Appends `?v=20260418` to `style.css` / `script.js` so browsers refetch (fixes the "new HTML + cached old CSS" render). Adds a defensive CSS reset and stronger visual hierarchy: gradient accent bar, portrait frame, gradient section headings, DOI pill badges, project card hover, sticky translucent section nav with active-section underline.
- **`b9a37ca` — Add two TSMC-era patents to Patents section.**
  - Method for Detecting Target Substance — L. Lu, US `US20260023060A1`, 2026
  - Brush for Cleaning Wafers After CMP Process — Jhih-Fong Lin, Liqing Wen, Le Lu (DGC), US `US20240180324A1`, 2024

Each patent entry links to Google Patents via a tinted badge consistent with the publication DOIs.

## Test plan

- [x] `python3 -m http.server` — confirmed `index.html`, `style.css?v=20260418`, `script.js?v=20260418`, `images/profile.jpg`, `ModelsComparison_v1.02.html` all return 200.
- [x] After merge, hard-refresh `https://lulelaboratory.github.io/` and confirm:
  - Portrait rendered as 200 px circle with indigo gradient ring
  - Patents section lists 4 entries, most recent first
  - Section nav underline follows scroll

https://claude.ai/code/session_018QXKLqqQm1NnEudvFM3n5Y