### PR TITLE
Add MLIP Hub project to portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,6 +232,26 @@
         <h2>Projects</h2>
         <div class="project-grid">
           <article class="project">
+            <h3>MLIP Hub</h3>
+            <p>
+              An interactive, curated catalog of machine-learning interatomic
+              potentials (MLIPs). Models are organized by architectural lineage
+              — descriptor, invariant and equivariant graph neural networks, and
+              transformer / foundation models — as a conceptual reference map
+              rather than a benchmark. Offers curated, force-directed, and
+              timeline (&ldquo;tree of life&rdquo;) layouts, detailed model cards
+              linking to code and papers, full-text search, and side-by-side
+              capability comparison with CSV export.
+            </p>
+            <p class="stack">Next.js · TypeScript · Tailwind CSS · Vercel</p>
+            <p class="project-links">
+              <a href="https://www.mliphub.com" target="_blank" rel="noopener">www.mliphub.com</a>
+              ·
+              <a href="https://github.com/lulelaboratory/mlip-landscape" target="_blank" rel="noopener">GitHub</a>
+            </p>
+          </article>
+
+          <article class="project">
             <h3>MD Fragment Analyzer</h3>
             <p>
               Python tool for fragment analysis of molecular dynamics


### PR DESCRIPTION
## Summary
Added a new project entry for MLIP Hub to the projects section of the portfolio website.

## Changes
- Added a new project article for MLIP Hub, an interactive catalog of machine-learning interatomic potentials
- Included project description highlighting key features: curated model organization by architectural lineage, multiple layout options (curated, force-directed, timeline), model cards, full-text search, and capability comparison with CSV export
- Added technology stack: Next.js, TypeScript, Tailwind CSS, and Vercel
- Included links to the live site (www.mliphub.com) and GitHub repository (lulelaboratory/mlip-landscape)

## Implementation Details
- Follows the existing project article structure and styling conventions
- Uses semantic HTML with proper accessibility attributes (target="_blank" with rel="noopener")
- Positioned as the first project in the grid, appearing before MD Fragment Analyzer

https://claude.ai/code/session_01Evg3uJsoF9ceenxkXiUm5U